### PR TITLE
Fix outdated OpenAI warning text

### DIFF
--- a/run.py
+++ b/run.py
@@ -32,7 +32,7 @@ except ImportError:
     openai_new_api = False  # old openai api version
     print(
         "Warning: Your OpenAI version is outdated. \n "
-        "Please update as specified in requirement.txt. \n "
+        "Please update as specified in requirements.txt. \n "
         "The old API interface is deprecated and will no longer be supported.")
 
 


### PR DESCRIPTION
## Summary
- reference `requirements.txt` in the OpenAI version warning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886f7802f70832f8309af3f02da3386