### PR TITLE
Add pytest for Roster duplicate detection

### DIFF
--- a/tests/test_codes.py
+++ b/tests/test_codes.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import types
+
+# Stub heavy dependencies for chatdev.utils imported by chatdev.codes
+camel = types.ModuleType('camel')
+camel.messages = types.ModuleType('camel.messages')
+camel.messages.system_messages = types.ModuleType('camel.messages.system_messages')
+class SystemMessage:
+    pass
+camel.messages.system_messages.SystemMessage = SystemMessage
+sys.modules['camel'] = camel
+sys.modules['camel.messages'] = camel.messages
+sys.modules['camel.messages.system_messages'] = camel.messages.system_messages
+
+visualizer_app = types.ModuleType('visualizer.app')
+def send_msg(role, content):
+    pass
+visualizer_app.send_msg = send_msg
+sys.modules['visualizer.app'] = visualizer_app
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(ROOT)
+
+from chatdev.codes import Codes
+
+
+def test_format_code_removes_empty_lines():
+    c = Codes()
+    formatted = c._format_code("line1\n\nline2\n")
+    assert formatted == "line1\nline2"
+
+
+def test_load_from_hardware(tmp_path):
+    file = tmp_path / "sample.py"
+    file.write_text("print('hi')\n\n")
+    codes = Codes()
+    codes._load_from_hardware(str(tmp_path))
+    assert "sample.py" in codes.codebooks
+    assert codes.codebooks["sample.py"] == "print('hi')"
+
+
+def test_get_codes_single_file():
+    codes = Codes()
+    codes.codebooks["a.py"] = "print('a')"
+    expected = "a.py\n```python\nprint('a')\n```\n\n"
+    assert codes._get_codes() == expected

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -1,0 +1,33 @@
+import os
+import sys
+
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(ROOT)
+
+from chatdev.roster import Roster
+
+
+def test_exist_employee_case_insensitive():
+    r = Roster()
+    r._recruit("Alice")
+    assert r._exist_employee("alice") is True
+
+
+def test_exist_employee_ignore_spaces_and_underscores():
+    r = Roster()
+    r._recruit("Alice_Smith")
+    assert r._exist_employee("Alice Smith") is True
+
+
+def test_exist_employee_new_name():
+    r = Roster()
+    r._recruit("Alice")
+    assert r._exist_employee("Bob") is False
+
+
+def test_exist_employee_spaces_in_record():
+    r = Roster()
+    r._recruit("Alice Smith")
+    assert r._exist_employee("Alice_Smith") is True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import types
+
+# Prepare dummy modules so chatdev.utils can be imported without heavy deps
+camel = types.ModuleType('camel')
+camel.messages = types.ModuleType('camel.messages')
+camel.messages.system_messages = types.ModuleType('camel.messages.system_messages')
+class SystemMessage:
+    pass
+camel.messages.system_messages.SystemMessage = SystemMessage
+sys.modules['camel'] = camel
+sys.modules['camel.messages'] = camel.messages
+sys.modules['camel.messages.system_messages'] = camel.messages.system_messages
+
+visualizer_app = types.ModuleType('visualizer.app')
+def send_msg(role, content):
+    pass
+visualizer_app.send_msg = send_msg
+sys.modules['visualizer.app'] = visualizer_app
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(ROOT)
+
+from chatdev.utils import convert_to_markdown_table, escape_string
+
+
+def test_convert_to_markdown_table():
+    table = convert_to_markdown_table([('a', '1'), ('b', '2')])
+    assert table == "| Parameter | Value |\n| --- | --- |\n| **a** | 1 |\n| **b** | 2 |"
+
+
+def test_escape_string_html():
+    assert escape_string('<b>hi</b>\nnew') == 'hi new'


### PR DESCRIPTION
## Summary
- add a `tests/` folder
- create `tests/test_roster.py` with pytest unit tests for `_exist_employee`
- verify detection ignores case, spaces and underscores
- add coverage for `Codes` and `utils` helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886f78fbb2c832fadced411a1431e57