### PR TITLE
Improve process output handling

### DIFF
--- a/chatdev/chat_env.py
+++ b/chatdev/chat_env.py
@@ -118,7 +118,8 @@ class ChatEnv:
                     shell=True,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
-                    creationflags=subprocess.CREATE_NEW_PROCESS_GROUP
+                    creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+                    text=True
                 )
             else:
                 command = "cd {}; ls -l; python3 main.py;".format(directory)
@@ -126,23 +127,30 @@ class ChatEnv:
                                            shell=True,
                                            preexec_fn=os.setsid,
                                            stdout=subprocess.PIPE,
-                                           stderr=subprocess.PIPE
+                                           stderr=subprocess.PIPE,
+                                           text=True
                                            )
-            time.sleep(3)
+            try:
+                # Wait for the process to finish and then collect output
+                process.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                # Terminate long running processes
+                if process.poll() is None:
+                    if "killpg" in dir(os):
+                        os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+                    else:
+                        os.kill(process.pid, signal.SIGTERM)
+                        if process.poll() is None:
+                            os.kill(process.pid, signal.CTRL_BREAK_EVENT)
+                process.wait()
+
+            stdout_data, stderr_data = process.communicate()
             return_code = process.returncode
-            # Check if the software is still running
-            if process.poll() is None:
-                if "killpg" in dir(os):
-                    os.killpg(os.getpgid(process.pid), signal.SIGTERM)
-                else:
-                    os.kill(process.pid, signal.SIGTERM)
-                    if process.poll() is None:
-                        os.kill(process.pid, signal.CTRL_BREAK_EVENT)
 
             if return_code == 0:
                 return False, success_info
             else:
-                error_output = process.stderr.read().decode('utf-8')
+                error_output = stderr_data
                 if error_output:
                     if "Traceback".lower() in error_output.lower():
                         errs = error_output.replace(directory + "/", "")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+import sys
+import types
+
+dummy = types.ModuleType("dummy")
+for name in ["openai", "markdown", "tiktoken", "pandas"]:
+    if name not in sys.modules:
+        sys.modules[name] = dummy
+dummy.OpenAI = object
+sys.modules.setdefault("colorama", dummy)
+dummy.Fore = object
+dummy.Style = object
+sys.modules.setdefault("faiss", dummy)
+sys.modules.setdefault("yaml", dummy)
+sys.modules.setdefault("easydict", dummy)
+dummy.EasyDict = dict
+
+# Provide minimal Flask stub
+if "flask" not in sys.modules:
+    flask_stub = types.ModuleType("flask")
+
+    class _Flask:
+        def __init__(self, *args, **kwargs):
+            import logging
+            self.logger = logging.getLogger("dummy")
+
+        def route(self, *args, **kwargs):
+            def decorator(fn):
+                return fn
+            return decorator
+
+    flask_stub.Flask = _Flask
+    flask_stub.send_from_directory = lambda *a, **kw: None
+    flask_stub.request = object()
+    flask_stub.jsonify = lambda *a, **kw: None
+    sys.modules["flask"] = flask_stub
+
+# Stub camel package with minimal structure
+camel_pkg = types.ModuleType("camel")
+camel_messages_pkg = types.ModuleType("camel.messages")
+system_messages_pkg = types.ModuleType("camel.messages.system_messages")
+system_messages_pkg.SystemMessage = object
+
+sys.modules.setdefault("camel", camel_pkg)
+sys.modules.setdefault("camel.messages", camel_messages_pkg)
+sys.modules.setdefault("camel.messages.system_messages", system_messages_pkg)
+
+import os
+os.environ.setdefault("OPENAI_API_KEY", "test")

--- a/tests/test_exist_bugs.py
+++ b/tests/test_exist_bugs.py
@@ -1,0 +1,32 @@
+import os
+import tempfile
+from chatdev.chat_env import ChatEnv, ChatEnvConfig
+
+
+def create_env(tmp_path, script):
+    cfg = ChatEnvConfig(
+        clear_structure=True,
+        gui_design=False,
+        git_management=False,
+        incremental_develop=False,
+        background_prompt="",
+        with_memory=False,
+    )
+    env = ChatEnv(cfg)
+    env.set_directory(str(tmp_path / "proj"))
+    (tmp_path / "proj" / "main.py").write_text(script)
+    return env
+
+
+def test_exist_bugs_success(tmp_path):
+    env = create_env(tmp_path, "print('ok')")
+    has_bug, info = env.exist_bugs()
+    assert has_bug is False
+    assert "successfully" in info
+
+
+def test_exist_bugs_failure(tmp_path):
+    env = create_env(tmp_path, "raise ValueError('fail')")
+    has_bug, info = env.exist_bugs()
+    assert has_bug is True
+    assert "Traceback" in info


### PR DESCRIPTION
## Summary
- capture process output in text mode for simpler error handling
- remove manual decoding when checking process exit status
- wait for the subprocess to exit before reading output and deciding success
- add unit tests for `exist_bugs`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886f789fab8832f81046bd317d9c753